### PR TITLE
Add gRPC endpoint for load balancing information

### DIFF
--- a/protobufs/service.proto
+++ b/protobufs/service.proto
@@ -18,9 +18,24 @@ message OutputArrays {
     string uuid = 2;
 }
 
+// Input message for a GetLoad query
+message GetLoadParams {}
+
+// Result messae of a GetLoad query
+message GetLoadResult {
+    // Number of currently connected clients.
+    int32 n_clients = 1;
+    // Current system-wide CPU load average.
+    float percent_cpu = 2;
+    // Current percentage of used RAM.
+    float percent_ram = 3;
+}
+
 // The most generic type of compute operation,
 // computing NumPy arrays from NumPy arrays.
 service ArraysToArraysService {
     rpc Evaluate(InputArrays) returns (OutputArrays);
     rpc EvaluateStream(stream InputArrays) returns (stream OutputArrays);
+    // Get the current load of the worker node.
+    rpc GetLoad(GetLoadParams) returns (GetLoadResult);
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ betterproto==2.0.0b5
 black
 isort
 numpy
+psutil


### PR DESCRIPTION
This gets a simple prerequisite for client-side load balancing done:
A `GetLoad` endpoint that returns the number of clients, CPU load and RAM usage.

Using this endpoint, follow-up work towards #14 can start.