### PR TITLE
Add `AsyncOp` and `ParallelAsyncOp`

### DIFF
--- a/aesara_federated/__init__.py
+++ b/aesara_federated/__init__.py
@@ -1,5 +1,6 @@
 try:
     from .op import ArraysToArraysOp, LogpGradOp, LogpOp
+    from .op_async import AsyncOp
 except ModuleNotFoundError:
     pass
 from .common import (

--- a/aesara_federated/op_async.py
+++ b/aesara_federated/op_async.py
@@ -1,0 +1,100 @@
+import asyncio
+from typing import Any, Sequence
+
+from aesara.graph.basic import Apply, Variable
+from aesara.graph.op import Op, OutputStorageType, ParamsInputType
+
+
+class AsyncOp(Op):
+    def perform(
+        self,
+        node: Apply,
+        inputs: Sequence[Any],
+        output_storage: OutputStorageType,
+        params: ParamsInputType = None,
+    ) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+        coro = self.perform_async(node, inputs, output_storage, params)
+        return loop.run_until_complete(coro)
+
+    async def perform_async(
+        self,
+        node: Apply,
+        inputs: Sequence[Any],
+        output_storage: OutputStorageType,
+        params: ParamsInputType = None,
+    ) -> None:
+        raise NotImplementedError()
+
+
+class ParallelAsyncOp(AsyncOp):
+    """An op that parallelizes the `perform_async` methods of multiple `AsyncOp` apply nodes."""
+
+    def __init__(self, applies: Sequence[Apply]) -> None:
+        for a, apply in enumerate(applies):
+            if not isinstance(apply.op, AsyncOp):
+                raise ValueError(
+                    f"The owner of apply node {a} is not an `AsyncOp`. "
+                    "All apply nodes given to given to `ParallelAsyncOp` must be owned by an `AsyncOp`."
+                )
+        self.applies = applies
+        super().__init__()
+
+    def make_node(self, *inputs: Variable) -> Apply:
+        # Check number of inputs
+        nin_exp = sum(a.nin for a in self.applies)
+        nin_act = len(inputs)
+        if nin_act != nin_exp:
+            raise ValueError(
+                f"Unexpected number of inputs to `ParallelAsyncOp` {self}. "
+                f"Got {nin_act} inputs but expected {nin_exp} for {len(self.applies)} apply nodes."
+            )
+
+        # Create new unowned output variables
+        outputs = []
+        for app in self.applies:
+            for out in app.outputs:
+                outputs.append(out.type())
+
+        # Create a new apply node that takes does the job of all child applies at once.
+        return Apply(
+            op=self,
+            inputs=inputs,
+            outputs=outputs,
+        )
+
+    def perform(
+        self,
+        node: Apply,
+        inputs: Sequence[Any],
+        output_storage: OutputStorageType,
+        params: ParamsInputType = None,
+    ) -> None:
+        # Create coroutines the performing the taks of each child node
+        coros = []
+        ifrom = 0
+        ofrom = 0
+        for apply in self.applies:
+            ito = ifrom + apply.nin
+            oto = ofrom + apply.nout
+            coros.append(
+                apply.op.perform_async(
+                    apply, inputs[ifrom:ito], output_storage[ofrom:oto], params=params
+                )
+            )
+            ifrom = ito
+            ofrom = oto
+
+        # Wait for completion of all sub-performs
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+        futures = [asyncio.ensure_future(c, loop=loop) for c in coros]
+        pool = asyncio.gather(*futures, return_exceptions=True)
+        loop.run_until_complete(pool)
+        # Output storage was modified inplace by the child operations.
+        return

--- a/aesara_federated/test_op_async.py
+++ b/aesara_federated/test_op_async.py
@@ -1,0 +1,78 @@
+import asyncio
+import time
+
+import aesara
+import aesara.tensor as at
+import pytest
+from aesara.graph.basic import Apply, Variable
+from aesara.graph.op import Op
+
+from aesara_federated import op_async
+
+
+class _AsyncDelay(op_async.AsyncOp):
+    def make_node(self, delay: Variable) -> Apply:
+        return Apply(
+            op=self,
+            inputs=[delay],
+            outputs=[at.scalar()],
+        )
+
+    async def perform_async(self, node, inputs, output_storage, params=None) -> None:
+        delay = inputs[0]
+        # The asyncio.sleep function is not accurate in comparison to the perf_counter.
+        # Therefore, this implementation uses the perf_counter such that the outer
+        # test code does not get confused by slightly too short delays.
+        t_start = time.perf_counter()
+        while time.perf_counter() - t_start < delay:
+            await asyncio.sleep(0.01)
+        output_storage[0][0] = delay
+
+
+class TestAsyncOp:
+    def test_perform(self):
+        delay_op = _AsyncDelay()
+        assert isinstance(delay_op, Op)
+
+        d = at.scalar()
+        out = delay_op(d)
+        # Compile a function to exclude compile time from delay measurement
+        f = aesara.function([d], [out])
+        ts = time.perf_counter()
+        f(0.5)
+        assert 0.5 < time.perf_counter() - ts < 0.6
+        pass
+
+
+class TestParallelAsyncOp:
+    def test_perform(self):
+        # Create two nodes that are the result of separate applies
+        d1 = at.scalar()
+        d2 = at.scalar()
+        dop = _AsyncDelay()
+        o1 = dop(d1)
+        o2 = dop(d2)
+
+        # Assert that the constructor checks the input owner types
+        with pytest.raises(ValueError, match="apply node 2 is not"):
+            op_async.ParallelAsyncOp([o1.owner, o2.owner, (o1 + o2).owner])
+
+        # Create a parallelized Op for these applies
+        pop = op_async.ParallelAsyncOp(applies=[o1.owner, o2.owner])
+
+        # Assert that make_node checks the number of inputs
+        with pytest.raises(ValueError, match="expected 2 for 2"):
+            pop(d1, d2, 3)
+
+        outs = pop(d1, d2)
+        dsum = outs[0] + outs[1]
+
+        # Evaluating the delays in parallel is faster than the sum of delays.
+        # We do this with a compiled function to exclude compile time from delay measurement.
+        f = aesara.function([d1, d2], [dsum])
+        t_start = time.perf_counter()
+        delay_sum = f(0.5, 0.2)[0]
+        t_took = time.perf_counter() - t_start
+        assert float(delay_sum) == 0.7
+        assert 0.5 < t_took < delay_sum
+        pass


### PR DESCRIPTION
This PR is the first step for async Ops with Aesara.

It introduces the `AsyncOp` class, and a `ParallelAsyncOp` that I plan to use in a graph-rewriting.

The tests are based on measuring the wall-clock execution time of a graph that involves `AsyncDelay` ops.

Closes #26

--------

Further reading on how the `Op`, `Apply` and `Variable` nodes relate to each other: https://aesara.readthedocs.io/en/latest/extending/graphstructures.html