### PR TITLE
Adapt imports to PyTensor 2.8.11

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - pip
   - pip:
     - betterproto[compiler]==2.0.0b5
-    - pymc==5.0.0
+    - pymc==5.0.1

--- a/pytensor_federated/__init__.py
+++ b/pytensor_federated/__init__.py
@@ -19,4 +19,4 @@ from .common import (
 from .service import ArraysToArraysService, ArraysToArraysServiceClient
 from .signatures import ComputeFunc, LogpFunc, LogpGradFunc
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/pytensor_federated/op_async.py
+++ b/pytensor_federated/op_async.py
@@ -5,7 +5,7 @@ import pytensor.tensor as at
 from pytensor.compile import optdb
 from pytensor.compile.ops import FromFunctionOp
 from pytensor.graph import FunctionGraph
-from pytensor.graph.basic import Apply, Variable, is_in_ancestors
+from pytensor.graph.basic import Apply, Variable, apply_depends_on
 from pytensor.graph.features import ReplaceValidate
 from pytensor.graph.op import Op, OutputStorageType, ParamsInputType
 from pytensor.graph.rewriting.basic import GraphRewriter
@@ -158,7 +158,7 @@ def find_parallelizable_applies(fg: FunctionGraph, op_cls: type) -> List[Apply]:
         if not isinstance(apply.op, op_cls):
             continue
         # Does this node depend on any one of the already-collected?
-        if not any(is_in_ancestors(apply, a) for a in applies):
+        if not any(apply_depends_on(apply, a) for a in applies):
             applies.append(apply)
             continue
         elif len(applies) == 1:


### PR DESCRIPTION
The `pytensor.graph.basic.is_in_ancestors` function was renamed in PyTensor 2.8.11 and this version is pinned by PyMC 5.0.1.