### PR TITLE
Compatibility fix for PyTensor >=2.18.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,4 +12,4 @@ dependencies:
   - psutil
   - pip:
     - betterproto[compiler]==2.0.0b6
-    - pymc==5.8.0
+    - pymc==5.10.0

--- a/pytensor_federated/__init__.py
+++ b/pytensor_federated/__init__.py
@@ -19,4 +19,4 @@ from .common import (
 from .service import ArraysToArraysService, ArraysToArraysServiceClient
 from .signatures import ComputeFunc, LogpFunc, LogpGradFunc
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/pytensor_federated/wrapper_ops.py
+++ b/pytensor_federated/wrapper_ops.py
@@ -5,7 +5,7 @@ import pytensor
 import pytensor.tensor as at
 from pytensor.compile.ops import FromFunctionOp
 from pytensor.graph.basic import Apply, Variable
-from pytensor.graph.op import Op, OutputStorageType, ParamsInputType
+from pytensor.graph.op import Op, OutputStorageType
 
 from .op_async import AsyncFromFunctionOp, AsyncOp
 from .signatures import ComputeFunc, LogpFunc, LogpGradFunc
@@ -63,7 +63,6 @@ class LogpOp(Op):
         node: Apply,
         inputs: Sequence[np.ndarray],
         output_storage: OutputStorageType,
-        params: ParamsInputType = None,
     ) -> None:
         logp = self._logp_func(*inputs)
         output_storage[0][0] = logp
@@ -76,7 +75,6 @@ class AsyncLogpOp(AsyncOp, LogpOp):
         node: Apply,
         inputs: Sequence[Any],
         output_storage: OutputStorageType,
-        params: ParamsInputType = None,
     ) -> None:
         logp = await self._logp_func(*inputs)
         output_storage[0][0] = logp
@@ -111,7 +109,6 @@ class LogpGradOp(Op):
         node: Apply,
         inputs: Sequence[np.ndarray],
         output_storage: OutputStorageType,
-        params: ParamsInputType = None,
     ) -> None:
         logp, gradient = self._logp_grad_func(*inputs)
         output_storage[0][0] = logp
@@ -141,7 +138,6 @@ class AsyncLogpGradOp(AsyncOp, LogpGradOp):
         node: Apply,
         inputs: Sequence[Any],
         output_storage: OutputStorageType,
-        params: ParamsInputType = None,
     ) -> None:
         logp, gradient = await self._logp_grad_func(*inputs)
         output_storage[0][0] = logp


### PR DESCRIPTION
Adapts to the change of `Op` signature from https://github.com/pymc-devs/pytensor/pull/513 to restore compatibility with PyTensor >=2.18.1.