### PR TITLE
Bump workflow matrix to Python 3.12-3.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         pip install twine wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.12", "3.13", "3.14"]
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Bump workflow matrix to Python 3.12-3.14 regarding the releases of  `PyMC v6` requiring Python>=3.12 and `PyTensor v3`