### PR TITLE
Run tests on new PRs too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: test
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   test-job:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: \.(ipynb|nblink)$
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v6.0.0
   hooks:
     - id: check-merge-conflict
     - id: check-toml
@@ -10,14 +10,14 @@ repos:
     - id: end-of-file-fixer
     - id: requirements-txt-fixer
 - repo: https://github.com/PyCQA/isort
-  rev: 5.12.0
+  rev: 9.0.0a3
   hooks:
     - id: isort
       name: isort
       args: ["--profile", "black"]
       exclude: (pytensor_federated/rpc.py|pytensor_federated/npproto/)
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 26.5.1
   hooks:
     - id: black
       exclude: (pytensor_federated/rpc.py|pytensor_federated/npproto/)

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
 dependencies:
   - black
   - isort
-  - nest-asyncio
   - numpy
   - pytest
   - pytest-cov

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,8 @@ channels:
 dependencies:
   - black
   - isort
+  - gxx
+  - matplotlib
   - numpy
   - pytest
   - pytest-cov
@@ -11,4 +13,4 @@ dependencies:
   - psutil
   - pip:
     - betterproto[compiler]==2.0.0b6
-    - pymc>=5.17.0
+    - pymc>=6.0.0

--- a/protobufs/generate.py
+++ b/protobufs/generate.py
@@ -2,6 +2,7 @@
 This script regenerates the `core.py` module
 from protobuf definitions of core metadata structures.
 """
+
 import pathlib
 import shutil
 import subprocess

--- a/pytensor_federated/__init__.py
+++ b/pytensor_federated/__init__.py
@@ -19,4 +19,4 @@ from .common import (
 from .service import ArraysToArraysService, ArraysToArraysServiceClient
 from .signatures import ComputeFunc, LogpFunc, LogpGradFunc
 
-__version__ = "1.0.2"
+__version__ = "2.0.0"

--- a/pytensor_federated/common.py
+++ b/pytensor_federated/common.py
@@ -1,6 +1,7 @@
 """
 Wrappers around ArraysToArrays service commonly used signatures for modeling.
 """
+
 from typing import Sequence, Tuple
 
 import numpy as np

--- a/pytensor_federated/op_async.py
+++ b/pytensor_federated/op_async.py
@@ -111,22 +111,23 @@ class ParallelAsyncOp(AsyncOp):
         output_storage: OutputStorageType,
     ) -> None:
         # Create coroutines the performing the taks of each child node
-        coros = []
+        tasks = []
         ifrom = 0
         ofrom = 0
+        loop = get_useful_event_loop()
         for apply in self.applies:
             ito = ifrom + apply.nin
             oto = ofrom + apply.nout
-            coros.append(
-                apply.op.perform_async(apply, inputs[ifrom:ito], output_storage[ofrom:oto])
+            tasks.append(
+                loop.create_task(
+                    apply.op.perform_async(apply, inputs[ifrom:ito], output_storage[ofrom:oto])
+                )
             )
             ifrom = ito
             ofrom = oto
 
         # Wait for completion of all sub-performs
-        loop = get_useful_event_loop()
-        futures = [asyncio.ensure_future(c, loop=loop) for c in coros]
-        pool = asyncio.gather(*futures, return_exceptions=True)
+        pool = asyncio.gather(*tasks, return_exceptions=True)
         loop.run_until_complete(pool)
         # Output storage was modified inplace by the child operations.
         return

--- a/pytensor_federated/op_async.py
+++ b/pytensor_federated/op_async.py
@@ -5,10 +5,11 @@ import pytensor.tensor as at
 from pytensor.compile import optdb
 from pytensor.compile.ops import FromFunctionOp
 from pytensor.graph import FunctionGraph
-from pytensor.graph.basic import Apply, Variable, apply_depends_on
+from pytensor.graph.basic import Apply, Variable
 from pytensor.graph.features import ReplaceValidate
 from pytensor.graph.op import Op, OutputStorageType
 from pytensor.graph.rewriting.basic import GraphRewriter
+from pytensor.graph.traversal import apply_depends_on
 
 from .utils import get_useful_event_loop
 

--- a/pytensor_federated/signatures.py
+++ b/pytensor_federated/signatures.py
@@ -1,6 +1,7 @@
 """
 This module contains only type and signature definitions.
 """
+
 from typing import Callable, Sequence, Tuple
 
 import numpy as np

--- a/pytensor_federated/test_op_async.py
+++ b/pytensor_federated/test_op_async.py
@@ -41,7 +41,7 @@ class TestAsyncOp:
         d = at.scalar()
         out = delay_op(d)
         # Compile a function to exclude compile time from delay measurement
-        f = pytensor.function([d], [out])
+        f = pytensor.function([d], [out], mode="FAST_COMPILE")
         ts = time.perf_counter()
         f(0.5)
         assert 0.5 < time.perf_counter() - ts < 0.6
@@ -65,7 +65,7 @@ class TestAsyncFromFunctionOp:
         d = at.scalar()
         out = affo(d)
         # Compile a function to exclude compile time from delay measurement
-        f = pytensor.function([d], [out])
+        f = pytensor.function([d], [out], mode="FAST_COMPILE")
         ts = time.perf_counter()
         f(0.5)
         assert 0.5 < time.perf_counter() - ts < 0.6
@@ -97,12 +97,12 @@ class TestParallelAsyncOp:
 
         # Evaluating the delays in parallel is faster than the sum of delays.
         # We do this with a compiled function to exclude compile time from delay measurement.
-        f = pytensor.function([d1, d2], [dsum])
+        f = pytensor.function([d1, d2], [dsum], mode="FAST_RUN")
         t_start = time.perf_counter()
-        delay_sum = f(0.5, 0.2)[0]
+        delay_sum = f(1.5, 0.8)[0]
         t_took = time.perf_counter() - t_start
-        assert float(delay_sum) == 0.7
-        assert 0.5 < t_took < delay_sum
+        assert float(delay_sum) == 2.3
+        assert 0.8 < t_took < delay_sum
         pass
 
 
@@ -199,8 +199,8 @@ def test_fuse_asyncs_by_default():
     delay = _AsyncDelay()
     a, b = at.scalars("ab")
     c = delay(a) + delay(b)
-    f = pytensor.function([a, b], [c])
+    f = pytensor.function([a, b], [c], mode="FAST_RUN")
     t0 = time.perf_counter()
-    f(0.25, 0.25)
-    assert time.perf_counter() - t0 < 0.3
+    f(0.5, 0.5)
+    assert time.perf_counter() - t0 < 0.95
     pass

--- a/pytensor_federated/test_service.py
+++ b/pytensor_federated/test_service.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import platform
+import sys
 import time
 from typing import Sequence, Tuple
 from unittest import mock
@@ -72,6 +73,7 @@ def run_product_queries(client: service.ArraysToArraysServiceClient, n=100):
             prod = client.evaluate(a, b)
             assert prod == a * b
     except:
+        print(sys.exc_info())
         return False
     return True
 

--- a/pytensor_federated/test_utils.py
+++ b/pytensor_federated/test_utils.py
@@ -35,14 +35,4 @@ def test_get_useful_event_loop():
         assert loop.is_running()
 
     loop.run_until_complete(check_is_running())
-
-    # Calling `get_useful_event_loop` inside the coroutine
-    # should patch the already-running loop to support reentrance.
-    async def check_nesting():
-        assert loop.is_running()
-        nloop = utils.get_useful_event_loop()
-        assert hasattr(nloop, "_nest_patched")
-        loop.run_until_complete(asyncio.sleep(0.01))
-
-    loop.run_until_complete(check_nesting())
     pass

--- a/pytensor_federated/test_wrapper_ops.py
+++ b/pytensor_federated/test_wrapper_ops.py
@@ -113,7 +113,7 @@ def run_blackbox_linear_model_mcmc(port: int, cores: int, use_async: bool):
     # Check the posterior medians against the ground truth.
     # Print the summary so failure logs are more informative.
     print(arviz.summary(idata))
-    pst = idata.posterior.stack(sample=("chain", "draw"))
+    pst = idata.posterior.dataset.stack(sample=("chain", "draw"))
     np.testing.assert_allclose(np.median(pst.slope), 2, atol=0.1)
     return
 

--- a/pytensor_federated/utils.py
+++ b/pytensor_federated/utils.py
@@ -1,4 +1,5 @@
 """Generic utility functions that have only external dependencies."""
+
 import asyncio
 import logging
 from typing import Callable, Iterable, List, Optional, TypeVar

--- a/pytensor_federated/utils.py
+++ b/pytensor_federated/utils.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 from typing import Callable, Iterable, List, Optional, TypeVar
 
-import nest_asyncio
 import numpy as np
 
 T = TypeVar("T")
@@ -35,27 +34,18 @@ def argmin_none_or_func(
 
 
 def get_useful_event_loop() -> asyncio.AbstractEventLoop:
-    """Like `asyncio.get_event_loop()` but actually useful.
-
-    If the loop is already running, this function patches it using `nest_asyncio`,
-    because otherwise it would be impossible to run something on it.
-
-    Otherwise, the currently idle, or a new event loop is returned.
-
-    NOTE: This function achieves the same as running `nest_asyncio.apply()` once,
-          and using `asyncio.get_event_loop()`, but it has fewer side-effects.
-    """
-    # First try to get an already running event loop.
-    loop = asyncio._get_running_loop()
-    if loop is not None:
-        # We're already in a coroutine and `loop` is currently
-        # `await`ing the code that called this function.
-        # This loop can't `await` something new, but must be
-        # patched to support running a new loop inside.
-        if not hasattr(loop, "_nest_patched"):
-            _log.debug("Event loop is already running. Patching with nest_asyncio.")
-            nest_asyncio.apply(loop)
-    else:
-        # There is no currently active loop, so we must create a new one.
-        loop = asyncio.get_event_loop()
+    """Get a running/current/new event loop, in that order of priority."""
+    loop: asyncio.AbstractEventLoop
+    try:
+        # First try to get an already running event loop.
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # There is no running loop.
+        try:
+            # Is there a current, not running loop?
+            loop = asyncio.get_event_loop()
+        except:
+            # There's no current loop, so we must create one.
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
     return loop

--- a/pytensor_federated/wrapper_ops.py
+++ b/pytensor_federated/wrapper_ops.py
@@ -116,10 +116,15 @@ class LogpGradOp(Op):
             output_storage[1 + g][0] = grad
         return
 
-    def grad(self, inputs: Sequence[Variable], output_grads: List[Variable]) -> List[Variable]:
+    def pullback(
+        self,
+        inputs: Sequence[Variable],
+        outputs: Sequence[Variable],
+        cotangents: Sequence[Variable],
+    ) -> List[Variable]:
         # Unpack the output gradients of which we only need the
         # one w.r.t. logp
-        g_logp, *gs_inputs = output_grads
+        g_logp, *gs_inputs = cotangents
         for i, g in enumerate(gs_inputs):
             if not isinstance(g.type, pytensor.gradient.DisconnectedType):
                 raise ValueError(f"Can't propagate gradients wrt parameter {i+1}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 betterproto==2.0.0b7
 black
 isort
-nest-asyncio
 numpy
 psutil

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def package_files(directory):
     fp_typed = pathlib.Path(__packagename__, "py.typed")
     fp_typed.touch()
     paths = [str(fp_typed.absolute())]
-    for (path, _, filenames) in os.walk(directory):
+    for path, _, filenames in os.walk(directory):
         for filename in filenames:
             paths.append(os.path.join("..", path, filename))
     return paths

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,9 @@ setuptools.setup(
     classifiers=[
         "Programming Language :: Python",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "License :: OSI Approved :: GNU Affero General Public License v3",
     ],
     install_requires=open(pathlib.Path(ROOT, "requirements.txt")).readlines(),

--- a/test_demo_node.py
+++ b/test_demo_node.py
@@ -49,18 +49,22 @@ def test_linear_model_equivalence():
         intercept: 1.2,
         slope: 0.8,
     }
-    np.testing.assert_array_equal(
+    np.testing.assert_allclose(
         L_model.eval(test_point),
         L_federated.eval(test_point),
+        atol=1e-13,
+        rtol=1e-15,
     )
 
     # And now the gradient
     dL_model = pt.grad(L_model, [intercept, slope])
     dL_federated = pt.grad(L_federated, [intercept, slope])
     for dM, dF in zip(dL_model, dL_federated):
-        np.testing.assert_array_equal(
+        np.testing.assert_allclose(
             dM.eval(test_point),
             dF.eval(test_point),
+            atol=1e-13,
+            rtol=1e-15,
         )
     pass
 


### PR DESCRIPTION
Follow-up to https://github.com/michaelosthege/pytensor-federated/pull/84 to fix various incompatibilities created by updating Python and PyTensor.

* Adapted to `asyncio` breaking changes, on the way eliminating `nest-asyncio` workarounds that were introduced because of Jupyter but are no longer needed.
* PyTensor change to Numba as the default backend increased the overhead when calling compiled functions for the first time (I think?) therefore asserts of timing were adapted.
* Pre-commit hooks were updated